### PR TITLE
Dockerise root

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+Dockerfile
+target
+docs
+
+.dockerignore
+.env.sample
+.gitignore
+.git

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,11 @@
+# Postgres env
+POSTGRES_PASSWORD=
+POSTGRES_USER=
+POSTGRES_DB=
+POSTGRES_HOST=localhost
+
+# Root env
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/${POSTGRES_DB}
+RUST_ENV=development
+ROOT_SECRET=insecuresecret123 # Used to verify origin of attendance mutations
+ROOT_PORT=3000

--- a/.github/workflows/ghcr-deploy.yml
+++ b/.github/workflows/ghcr-deploy.yml
@@ -1,0 +1,55 @@
+# Inspired from: https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
+name: Create and publish Docker image to GHCR
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  workflow_dispatch:
+  push:
+    branches: ['master']
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Uses the `docker/login-action` action to log in to the Github Container Registry
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # This step uses `docker/metadata-action` to extract tags and labels that will be applied to the specified image.
+      # The `id` "meta" allows the output of this step to be referenced in a subsequent step.
+      # The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/amfoss/root
+          tags: |
+            # set latest tag for master branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }},priority=2000
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha
+
+      # This step uses the `docker/build-push-action` action to build the image. If the build succeeds, it pushes the image to GitHub Packages.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Build Stage
+FROM rust:slim-bullseye AS builder
+WORKDIR /build
+
+# Compile deps in a separate layer (for caching)
+COPY Cargo.toml Cargo.lock ./
+# Cargo requires at least one source file for compiling dependencies
+RUN mkdir src && echo "fn main() { println!(\"Hello, world!\"); }" > src/main.rs
+RUN apt-get update
+RUN apt install -y pkg-config libssl-dev
+RUN cargo build --release
+
+# Compile for release
+COPY ./src ./src
+COPY ./migrations ./migrations
+RUN rm ./target/release/deps/root*
+RUN cargo build --release
+
+# Release Stage
+FROM debian:bullseye-slim AS release
+COPY --from=builder /build/target/release/root /usr/local/bin
+CMD ["/usr/local/bin/root"]

--- a/README.md
+++ b/README.md
@@ -16,14 +16,9 @@ Root is our club's backend, responsible for collecting and distributing data fro
 
 2. Configure environment:
    ```bash
-   touch .env
+   cp .env.sample .env
    ```
-
-The following environment variables are required:
-* DATABASE_URL: Connection string to your DB.
-* RUST_ENV: Use "development" or "production" as applicable.
-* ROOT_SECRET: Used to verify the origin of mutation requests on attendance. Ask the maintainers for it.
-* BIND_ADDRESS: The IP address for `axum` to serve to. Typically `0.0.0.0:3000` for local deployments.
+   - Make sure that you have a postgres database running with the specified credentials.
 
 3. Setup database:
    ```bash


### PR DESCRIPTION
This PR implements docker containers and workflow files for pushing them to the Github container registry at [amfoss/packages](https://github.com/orgs/amfoss/packages)

One notable change is the removal/modification of the `BIND_PORT` environment variable, this was changed to only supply the port number. This was done to ensure compatibility with the master compose file at [infra-core](https://github.com/amfoss/infra-core/blob/main/docker-compose.yml) and also because bind addresses are irrelevant inside docker containers.

Note that we are moving to a twin branch workflow where the `master` branch will be used exclusively for releases and stable code, all fixes and features need to developed on separate branches and when its time for release they can be merged with `master`, this will kick off the deployment process.