### PR TITLE
Fix and update for streak mutations

### DIFF
--- a/src/graphql/mutations/streak_mutations.rs
+++ b/src/graphql/mutations/streak_mutations.rs
@@ -35,8 +35,11 @@ impl StreakMutations {
         let query = sqlx::query_as::<_, Streak>(
             "
         INSERT INTO StatusUpdateStreak VALUES ($1, 0, 0) 
-        ON CONFLICT (member_id) DO UPDATE 
-            SET current_streak = 0
+        ON CONFLICT (member_id) DO UPDATE
+            SET current_streak = CASE
+                WHEN StatusUpdateStreak.current_streak > 0 THEN 0
+                ELSE StatusUpdateStreak.current_streak - 1 
+            END
         RETURNING *",
         )
         .bind(input.member_id);

--- a/src/graphql/mutations/streak_mutations.rs
+++ b/src/graphql/mutations/streak_mutations.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use async_graphql::{Context, Error, Object, Result};
+use async_graphql::{Context, Object, Result};
 use sqlx::PgPool;
 
 use crate::models::status_update_streak::{StatusUpdateStreak as Streak, StreakInput};
@@ -14,29 +14,15 @@ impl StreakMutations {
     async fn increment_streak(&self, ctx: &Context<'_>, input: StreakInput) -> Result<Streak> {
         let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
 
-        // Ensure at least one identifier is provided
-        if input.member_id.is_none() && input.discord_id.is_none() {
-            return Err(Error::new(
-                "Either `member_id` or `discord_id` must be provided.",
-            ));
-        }
-
-        let mut sql = String::from("UPDATE Streaks SET current_streak = current_streak + 1, max_streak = GREATEST(max_streak, current_streak + 1) WHERE ");
-        if let Some(_) = input.member_id {
-            sql.push_str("member_id = $1");
-        } else if let Some(_) = input.discord_id {
-            sql.push_str("discord_id = $1");
-        }
-
-        sql.push_str(" RETURNING *");
-
-        let query = if let Some(member_id) = input.member_id {
-            sqlx::query_as::<_, Streak>(&sql).bind(member_id)
-        } else if let Some(discord_id) = input.discord_id {
-            sqlx::query_as::<_, Streak>(&sql).bind(discord_id)
-        } else {
-            return Err(Error::new("Invalid input."));
-        };
+        let query = sqlx::query_as::<_, Streak>(
+            "
+        INSERT INTO StatusUpdateStreak VALUES ($1, 1, 1) 
+        ON CONFLICT (member_id) DO UPDATE SET 
+            current_streak = StatusUpdateStreak.current_streak + 1, 
+            max_streak = GREATEST(StatusUpdateStreak.max_streak, StatusUpdateStreak.current_streak + 1)
+        RETURNING *",
+        )
+        .bind(input.member_id);
 
         let updated_streak = query.fetch_one(pool.as_ref()).await?;
 
@@ -46,30 +32,14 @@ impl StreakMutations {
     async fn reset_streak(&self, ctx: &Context<'_>, input: StreakInput) -> Result<Streak> {
         let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
 
-        // Ensure at least one identifier is provided
-        if input.member_id.is_none() && input.discord_id.is_none() {
-            return Err(Error::new(
-                "Either `member_id` or `discord_id` must be provided.",
-            ));
-        }
-
-        let mut sql = String::from("UPDATE Streaks SET current_streak = 0 WHERE ");
-
-        if let Some(_) = input.member_id {
-            sql.push_str("member_id = $1");
-        } else if let Some(_) = input.discord_id {
-            sql.push_str("discord_id = $1");
-        }
-
-        sql.push_str(" RETURNING *");
-
-        let query = if let Some(member_id) = input.member_id {
-            sqlx::query_as::<_, Streak>(&sql).bind(member_id)
-        } else if let Some(discord_id) = input.discord_id {
-            sqlx::query_as::<_, Streak>(&sql).bind(discord_id)
-        } else {
-            return Err(Error::new("Invalid input."));
-        };
+        let query = sqlx::query_as::<_, Streak>(
+            "
+        INSERT INTO StatusUpdateStreak VALUES ($1, 0, 0) 
+        ON CONFLICT (member_id) DO UPDATE 
+            SET current_streak = 0
+        RETURNING *",
+        )
+        .bind(input.member_id);
 
         let updated_streak = query.fetch_one(pool.as_ref()).await?;
         Ok(updated_streak)

--- a/src/models/status_update_streak.rs
+++ b/src/models/status_update_streak.rs
@@ -18,6 +18,5 @@ pub struct StatusUpdateStreakInfo {
 /// This struct is used to deserialize the input recieved for mutations on StatusUpdateStreak.
 #[derive(InputObject)]
 pub struct StreakInput {
-    pub member_id: Option<i32>,
-    pub discord_id: Option<String>,
+    pub member_id: i32,
 }


### PR DESCRIPTION
The streak mutation previously would throw an error if an entry did not exist for a member which would be the case everytime a new member is added. Additionally, I've realized I do not need the mutation to take discord_id as input anymore now that queries can handle relationships.   
