### PR TITLE
Add date field to attendance query

### DIFF
--- a/docs/attendance.md
+++ b/docs/attendance.md
@@ -32,6 +32,38 @@ struct AttendanceSummary {
 
 ## Queries
 
+### Get Attendance
+Retrieve attendance records by member ID or date.
+
+```graphql
+# Get attendance by member ID
+query {
+    attendance(memberId: 1) {
+        attendanceId
+        date
+        isPresent
+        timeIn
+        timeOut
+    }
+}
+```
+
+Get all attendance for a specific date
+
+```graphql
+query {
+    attendanceByDate(date: "2025-02-27") {
+        attendanceId
+        memberId
+        name
+        year
+        isPresent
+        timeIn
+        timeOut
+    }
+}
+```
+
 ### Mark Attendance
 Record a member's attendance for the day.
 

--- a/src/models/attendance.rs
+++ b/src/models/attendance.rs
@@ -48,3 +48,17 @@ pub struct MarkAttendanceInput {
     pub date: NaiveDate,
     pub hmac_signature: String,
 }
+
+/// This struct combines attendance data with member name for queries that need both.
+/// It joins the Attendance table with Member to include the member's name.
+#[derive(SimpleObject, FromRow)]
+pub struct AttendanceWithMember {
+    pub attendance_id: i32,
+    pub member_id: i32,
+    pub date: NaiveDate,
+    pub is_present: bool,
+    pub time_in: Option<NaiveTime>,
+    pub time_out: Option<NaiveTime>,
+    pub name: String,
+    pub year: i32,
+}


### PR DESCRIPTION
# Pull Request

## Description

This PR adds support for querying attendance records by a specific 

A new query `attendanceByDate` has been added that:

- Takes a specific date as a required parameter
- Returns attendance records for all members on that date
- Includes member names along with attendance data using a JOIN between the Attendance and Member tables

## Related Issues

- Closes #72 

## Additional Notes

This is a prerequisite for an issue in amD ([Link to amD issue](https://github.com/amfoss/amd/issues/5)).