### PR TITLE
workflows: fix clippy failing to read database_url

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,8 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: "sqlite::memory:"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
SQLx compile-time-checks need DATABASE_URL to be set to use query macros. Since it doesn't actually connect to the database, an in-memory SQLite should be fine.

# Update

It turns out you can't use SQLite since you'll be missing the database driver which is kept behind a feature on the dependency. Will need to spawn a postgres instance in the workflow.