### PR TITLE
workflows: fix clippy failing to read database_url

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     env:
-      DATABASE_URL: "postgresql://fake:fakepassword@fake.host:5555/fake_db"
+      SQLX_OFFLINE: "true"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.sqlx/query-917aa5a6796dc3531d87f82eb256c0c2bc483b8eeda01a9d5846c9b1785170c4.json
+++ b/.sqlx/query-917aa5a6796dc3531d87f82eb256c0c2bc483b8eeda01a9d5846c9b1785170c4.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n           SELECT \n            attendace.date,\n            COUNT(CASE WHEN attendace.is_present = true THEN attendace.member_id END) as total_present\n            FROM Attendance attendace\n            WHERE  attendace.date BETWEEN $1 AND $2\n            GROUP BY attendace.date\n            ORDER BY attendace.date\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "date",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 1,
+        "name": "total_present",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Date",
+        "Date"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "917aa5a6796dc3531d87f82eb256c0c2bc483b8eeda01a9d5846c9b1785170c4"
+}

--- a/.sqlx/query-ed098ee3012f3f6bd6d5d13b357dbf13b18bb4fa2526dcf2ae92ff706a55917a.json
+++ b/.sqlx/query-ed098ee3012f3f6bd6d5d13b357dbf13b18bb4fa2526dcf2ae92ff706a55917a.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT member.member_id as \"id!\", member.name as \"name!\",\n                COUNT(attendance.is_present)::int as \"present_days!\"\n            FROM Member member\n            LEFT JOIN Attendance attendance\n                ON member.member_id = attendance.member_id\n                AND attendance.is_present AND attendance.date >= CURRENT_DATE - INTERVAL '6 months'\n            GROUP BY member.member_id, member.name\n            ORDER BY member.member_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "name!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "present_days!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "ed098ee3012f3f6bd6d5d13b357dbf13b18bb4fa2526dcf2ae92ff706a55917a"
+}

--- a/src/daily_task/mod.rs
+++ b/src/daily_task/mod.rs
@@ -55,7 +55,10 @@ async fn execute_daily_task(pool: Arc<PgPool>) {
 // We need to add a record for every member because otherwise [`Presense`](https://www.github.com/presense) will only add present members to the DB, and we will have to JOIN Members and Attendance records for the day to get the absent members. In exchange for increased storage use, we get simpler queries for Home which needs the data for every member for every day so far. But as of Jan 2025, there are less than 50 members in the club and thus storage really shouldn't be an issue.
 /// Inserts new attendance records everyday for [`presense`](https://www.github.com/amfoss/presense) to update them later in the day and updates the AttendanceSummary table to keep track of monthly streaks.
 async fn update_attendance(members: Vec<Member>, pool: &PgPool) {
-    let today = chrono::Utc::now().with_timezone(&Kolkata).date().naive_local();
+    let today = chrono::Utc::now()
+        .with_timezone(&Kolkata)
+        .date()
+        .naive_local();
     debug!("Updating attendance on {}", today);
 
     for member in members {
@@ -96,7 +99,10 @@ async fn update_attendance(members: Vec<Member>, pool: &PgPool) {
 /// Checks if the member was present yesterday, and if so, increments the `days_attended` value. Otherwise, do nothing.
 async fn update_attendance_summary(member_id: i32, pool: &PgPool) {
     debug!("Updating summary for member #{}", member_id);
-    let today = chrono::Utc::now().with_timezone(&Kolkata).date().naive_local();
+    let today = chrono::Utc::now()
+        .with_timezone(&Kolkata)
+        .date()
+        .naive_local();
     let yesterday = today - chrono::Duration::days(1);
 
     // Check if the member was present yesterday

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ use async_graphql::EmptySubscription;
 use axum::http::{HeaderValue, Method};
 use chrono::FixedOffset;
 use sqlx::PgPool;
-use time::UtcOffset;
 use std::sync::Arc;
+use time::UtcOffset;
 use tower_http::cors::CorsLayer;
 use tracing::info;
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
@@ -71,7 +71,10 @@ async fn main() {
 /// Abstraction over initializing the global subscriber for tracing depending on whether it's in production or dev.
 fn setup_tracing(env: &str) {
     let kolkata_offset = UtcOffset::from_hms(5, 30, 0).expect("Hardcoded offset must be correct");
-    let timer = fmt::time::OffsetTime::new(kolkata_offset, time::format_description::well_known::Rfc2822);
+    let timer = fmt::time::OffsetTime::new(
+        kolkata_offset,
+        time::format_description::well_known::Rfc2822,
+    );
     if env == "production" {
         tracing_subscriber::registry()
             // In production, no need to write to stdout, write directly to file.
@@ -89,7 +92,12 @@ fn setup_tracing(env: &str) {
     } else {
         tracing_subscriber::registry()
             // Write to both stdout and file in development.
-            .with(fmt::layer().event_format(fmt::format().with_timer(timer.clone())).pretty().with_writer(std::io::stdout))
+            .with(
+                fmt::layer()
+                    .event_format(fmt::format().with_timer(timer.clone()))
+                    .pretty()
+                    .with_writer(std::io::stdout),
+            )
             .with(
                 fmt::layer()
                     .event_format(fmt::format().with_timer(timer.clone()))


### PR DESCRIPTION
SQLx compile-time checks require `DATABASE_URL` to be set for query macros. While an in-memory SQLite instance would normally suffice, it won't work because the necessary database driver is gated behind a feature flag. Therefore, a PostgreSQL instance needs to be spawned in the workflow.