### PR TITLE
Fix: Incorrect SQL statement in update_days_attended of mod.rs

### DIFF
--- a/src/daily_task/mod.rs
+++ b/src/daily_task/mod.rs
@@ -155,9 +155,9 @@ async fn update_days_attended(member_id: i32, today: NaiveDate, pool: &PgPool) {
                 r#"
                     UPDATE AttendanceSummary
                     SET days_attended = days_attended + 1
-                    WHERE member_id = $2
-                    AND year = $3
-                    AND month = $4
+                    WHERE member_id = $1
+                    AND year = $2
+                    AND month = $3
                 "#,
             )
             .bind(member_id)
@@ -177,7 +177,7 @@ async fn update_days_attended(member_id: i32, today: NaiveDate, pool: &PgPool) {
             sqlx::query(
                 r#"
                     INSERT INTO AttendanceSummary (member_id, year, month, days_attended)
-                    VALUES ($1, $2, 1)
+                    VALUES ($1, $2, $3, 1)
                 "#,
             )
             .bind(member_id)


### PR DESCRIPTION
There is issue with the numbering of placeholders in the `update_days_attended` function. 

The `UPDATE` statement had:  
```sql
UPDATE AttendanceSummary
SET days_attended = days_attended + 1
WHERE member_id = $2
AND year = $3
AND month = $4
```

This was wrong because the placeholders didn’t match the parameters being passed. The correct order should be:
```sql
UPDATE AttendanceSummary
SET days_attended = days_attended + 1
WHERE member_id = $1
AND year = $2
AND month = $3
```

Similarly, the below `INSERT` statement didn't have the placeholder `$3` specified for month.
```rust
sqlx::query(
                r#"
                    INSERT INTO AttendanceSummary (member_id, year, month, days_attended)
                    VALUES ($1, $2, $3, 1)
                "#,
            )
            .bind(member_id)
            .bind(year)
            .bind(month)
            .execute(pool)
            .await
            .unwrap();
```