### PR TITLE
Changes to Streak queries

### DIFF
--- a/src/graphql/queries/streak_queries.rs
+++ b/src/graphql/queries/streak_queries.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::models::{member::Member, status_update_streak::StatusUpdateStreak as Streak};
+use crate::models::status_update_streak::StatusUpdateStreak as Streak;
 use async_graphql::{Context, Object, Result};
 use sqlx::PgPool;
 
@@ -9,58 +9,16 @@ pub struct StreakQueries;
 
 #[Object]
 impl StreakQueries {
-    async fn streak(
-        &self,
-        ctx: &Context<'_>,
-        member_id: Option<i32>,
-        roll_no: Option<String>,
-        discord_id: Option<String>,
-    ) -> Result<Streak> {
+    async fn streak(&self, ctx: &Context<'_>, member_id: i32) -> Result<Streak> {
         let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
 
-        if let Some(id) = member_id {
-            let streak_query = sqlx::query_as::<_, Streak>(
-                "SELECT current_streak, max_streak FROM StatusUpdateStreak WHERE member_id = $1",
-            )
-            .bind(id)
-            .fetch_one(pool.as_ref())
-            .await?;
-
-            return Ok(streak_query);
-        }
-
-        let member_query = if let Some(roll) = roll_no {
-            sqlx::query_as::<_, Member>("SELECT * FROM Member WHERE roll_no = $1")
-                .bind(roll)
-                .fetch_one(pool.as_ref())
-                .await
-        } else if let Some(discord) = discord_id {
-            sqlx::query_as::<_, Member>("SELECT * FROM Member WHERE discord_id = $1")
-                .bind(discord)
-                .fetch_one(pool.as_ref())
-                .await
-        } else {
-            return Err(async_graphql::Error::new(
-                "At least one key (member_id, roll_no, discord_id) must be specified.",
-            ));
-        };
-
-        let member = match member_query {
-            Ok(member) => member,
-            Err(_) => {
-                return Err(async_graphql::Error::new(
-                    "No member found with the given criteria.",
-                ))
-            }
-        };
-
-        let streak_query = sqlx::query_as::<_, Streak>(
-            "SELECT current_streak, max_streak FROM Streak WHERE member_id = $1",
+        Ok(sqlx::query_as::<_, Streak>(
+            "SELECT current_streak, max_streak FROM StatusUpdateStreak WHERE member_id = $1",
         )
-        .bind(member.member_id)
+        .bind(member_id)
         .fetch_one(pool.as_ref())
-        .await?;
+        .await?)
+    }
 
-        Ok(streak_query)
     }
 }

--- a/src/graphql/queries/streak_queries.rs
+++ b/src/graphql/queries/streak_queries.rs
@@ -20,5 +20,13 @@ impl StreakQueries {
         .await?)
     }
 
+    async fn streaks(&self, ctx: &Context<'_>) -> Result<Vec<Streak>> {
+        let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
+
+        Ok(
+            sqlx::query_as::<_, Streak>("SELECT * FROM StatusUpdateStreak")
+                .fetch_all(pool.as_ref())
+                .await?,
+        )
     }
 }


### PR DESCRIPTION
- Adds a query `streaks` that returns streak data of every member.
- Removes unused arguments to the `streak`  query, since only home uses it and home exclusively uses `member_id`.