### PR TITLE
Add group_id to AttendanceWithMember results

### DIFF
--- a/src/graphql/queries/attendance_queries.rs
+++ b/src/graphql/queries/attendance_queries.rs
@@ -30,7 +30,7 @@ impl AttendanceQueries {
 
         let records = sqlx::query_as::<_, AttendanceWithMember>(
             "SELECT att.attendance_id, att.member_id, att.date, att.is_present,
-                    att.time_in, att.time_out, mem.name, mem.year
+                    att.time_in, att.time_out, mem.name, mem.year, mem.group_id
              FROM Attendance att
              JOIN Member mem ON att.member_id = mem.member_id
              WHERE att.date = $1",

--- a/src/models/attendance.rs
+++ b/src/models/attendance.rs
@@ -56,4 +56,5 @@ pub struct AttendanceWithMember {
     pub time_out: Option<NaiveTime>,
     pub name: String,
     pub year: i32,
+    pub group_id: i32,
 }


### PR DESCRIPTION
**Changes Made:**
- Updated the SQL query in `AttendanceWithMember` to include `group_id` from the Member table.
- Modified the `AttendanceWithMember` struct to include the group_id field.

Reason for Change:
Ensures that group_id is included in the attendance records, which will be needed for separating the members according to their groups.
