### PR TITLE
feat: add updateMember mutation for updating member information

### DIFF
--- a/src/graphql/mutations/member_mutations.rs
+++ b/src/graphql/mutations/member_mutations.rs
@@ -1,11 +1,9 @@
-use std::sync::Arc;
-
+use crate::models::member::{CreateMemberInput, Member, UpdateMemberInput};
 use async_graphql::{Context, Object, Result};
 use chrono::Local;
 use chrono_tz::Asia::Kolkata;
 use sqlx::PgPool;
-
-use crate::models::member::{CreateMemberInput, Member};
+use std::sync::Arc;
 
 #[derive(Default)]
 pub struct MemberMutations;
@@ -15,8 +13,8 @@ impl MemberMutations {
     #[graphql(name = "createMember")]
     async fn create_member(&self, ctx: &Context<'_>, input: CreateMemberInput) -> Result<Member> {
         let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
-
         let now = Local::now().with_timezone(&Kolkata).date_naive();
+
         let member = sqlx::query_as::<_, Member>(
             "INSERT INTO Member (roll_no, name, email, sex, year, hostel, mac_address, discord_id, group_id, created_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING *"
@@ -31,6 +29,40 @@ impl MemberMutations {
         .bind(&input.discord_id)
         .bind(input.group_id)
         .bind(now)
+        .fetch_one(pool.as_ref())
+        .await?;
+
+        Ok(member)
+    }
+
+    #[graphql(name = "updateMember")]
+    async fn update_member(&self, ctx: &Context<'_>, input: UpdateMemberInput) -> Result<Member> {
+        let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
+
+        let member = sqlx::query_as::<_, Member>(
+            "UPDATE Member SET
+                roll_no = COALESCE($1, roll_no),
+                name = COALESCE($2, name),
+                email = COALESCE($3, email),
+                sex = COALESCE($4, sex),
+                year = COALESCE($5, year),
+                hostel = COALESCE($6, hostel),
+                mac_address = COALESCE($7, mac_address),
+                discord_id = COALESCE($8, discord_id),
+                group_id = COALESCE($9, group_id)
+            WHERE member_id = $10
+            RETURNING *",
+        )
+        .bind(input.roll_no)
+        .bind(input.name)
+        .bind(input.email)
+        .bind(input.sex)
+        .bind(input.year)
+        .bind(input.hostel)
+        .bind(input.mac_address)
+        .bind(input.discord_id)
+        .bind(input.group_id)
+        .bind(input.member_id)
         .fetch_one(pool.as_ref())
         .await?;
 

--- a/src/models/member.rs
+++ b/src/models/member.rs
@@ -39,3 +39,17 @@ pub struct CreateMemberInput {
     pub discord_id: String,
     pub group_id: i32,
 }
+
+#[derive(InputObject)]
+pub struct UpdateMemberInput {
+    pub member_id: i32,
+    pub roll_no: Option<String>,
+    pub name: Option<String>,
+    pub email: Option<String>,
+    pub sex: Option<Sex>,
+    pub year: Option<i32>,
+    pub hostel: Option<String>,
+    pub mac_address: Option<String>,
+    pub discord_id: Option<String>,
+    pub group_id: Option<i32>,
+}


### PR DESCRIPTION
## Description
Implements the `updateMember` mutation to allow updating member information as requested in #114.

## Problem
"Currently a mutation exists to insert a new member but nothing exists to update the data of a specific member."

## Solution
- Added `UpdateMemberInput` struct with optional fields for partial updates
- Added `updateMember` mutation using COALESCE for null-safe updates

## Testing
Tested locally with GraphQL playground:
- Created a test member
- Updated individual fields (name, email, year)
- Verified unmodified fields remain unchanged

Closes #114