### PR TITLE
Add 'track' field to Member model and update docs

### DIFF
--- a/docs/member.md
+++ b/docs/member.md
@@ -17,6 +17,7 @@ struct Member {
     mac_address: String,
     discord_id: String,
     group_id: i32,
+    track: String,
 }
 ```
 
@@ -53,6 +54,7 @@ mutation {
             macAddress: "XX:XX:XX:XX:XX:XX"
             discordId: "123456789"
             groupId: 1
+            track: "web"
         }
     ) {
         memberId

--- a/migrations/20250602174736_add_track_feild_to_members.sql
+++ b/migrations/20250602174736_add_track_feild_to_members.sql
@@ -1,0 +1,3 @@
+-- Add migration script here
+ALTER TABLE Member
+ADD COLUMN track VARCHAR(255);

--- a/src/graphql/mutations/member_mutations.rs
+++ b/src/graphql/mutations/member_mutations.rs
@@ -28,7 +28,7 @@ impl MemberMutations {
         .bind(&input.mac_address)
         .bind(&input.discord_id)
         .bind(input.group_id)
-        .bind(input.track)
+        .bind(&input.track)
         .bind(now)
         .fetch_one(pool.as_ref())
         .await?;

--- a/src/graphql/mutations/member_mutations.rs
+++ b/src/graphql/mutations/member_mutations.rs
@@ -16,8 +16,8 @@ impl MemberMutations {
         let now = Local::now().with_timezone(&Kolkata).date_naive();
 
         let member = sqlx::query_as::<_, Member>(
-            "INSERT INTO Member (roll_no, name, email, sex, year, hostel, mac_address, discord_id, group_id, created_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING *"
+            "INSERT INTO Member (roll_no, name, email, sex, year, hostel, mac_address, discord_id, group_id, track, created_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING *"
         )
         .bind(&input.roll_no)
         .bind(&input.name)
@@ -28,6 +28,7 @@ impl MemberMutations {
         .bind(&input.mac_address)
         .bind(&input.discord_id)
         .bind(input.group_id)
+        .bind(input.track)
         .bind(now)
         .fetch_one(pool.as_ref())
         .await?;
@@ -49,8 +50,9 @@ impl MemberMutations {
                 hostel = COALESCE($6, hostel),
                 mac_address = COALESCE($7, mac_address),
                 discord_id = COALESCE($8, discord_id),
-                group_id = COALESCE($9, group_id)
-            WHERE member_id = $10
+                group_id = COALESCE($9, group_id),
+                track = COALESCE($10, track)
+            WHERE member_id = $11
             RETURNING *",
         )
         .bind(input.roll_no)
@@ -62,6 +64,7 @@ impl MemberMutations {
         .bind(input.mac_address)
         .bind(input.discord_id)
         .bind(input.group_id)
+        .bind(input.track)
         .bind(input.member_id)
         .fetch_one(pool.as_ref())
         .await?;

--- a/src/models/member.rs
+++ b/src/models/member.rs
@@ -23,6 +23,7 @@ pub struct Member {
     pub mac_address: String,
     pub discord_id: String,
     pub group_id: i32,
+    pub track: Option<String>,
     #[graphql(skip)] // Don't expose internal fields/meta-data
     pub created_at: NaiveDateTime,
 }
@@ -38,6 +39,7 @@ pub struct CreateMemberInput {
     pub mac_address: String,
     pub discord_id: String,
     pub group_id: i32,
+    pub track: Option<String>,
 }
 
 #[derive(InputObject)]
@@ -52,4 +54,5 @@ pub struct UpdateMemberInput {
     pub mac_address: Option<String>,
     pub discord_id: Option<String>,
     pub group_id: Option<i32>,
+    pub track: Option<String>,
 }


### PR DESCRIPTION
- Added `track` field to Member struct and database migration
- Updated createMember and updateMember mutations to handle `track`
- Modified Member queries to include `track` field
- Updated documentation to reflect the addition of `track` field

Closes #117 