### PR TITLE
Update .env.sa Fix: Match ROOT_PORT in .env.sample with READMEmple

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,4 +8,4 @@ POSTGRES_HOST=localhost
 ROOT_DB_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/${POSTGRES_DB}
 RUST_ENV=development
 ROOT_SECRET=insecuresecret123 # Used to verify origin of attendance mutations
-ROOT_PORT=3000
+ROOT_PORT=8000


### PR DESCRIPTION
The README specifies that the GraphQL server should be available at http://localhost:8000/graphql. 
However, the .env.sample file had ROOT_PORT set to 3000.

This PR updates the ROOT_PORT value to 8000 in the .env.sample file to match the README instructions and avoid confusion for new contributors during setup.
