### PR TITLE
Return track in attendance_by_date

### DIFF
--- a/src/graphql/queries/attendance_queries.rs
+++ b/src/graphql/queries/attendance_queries.rs
@@ -30,7 +30,7 @@ impl AttendanceQueries {
 
         let records = sqlx::query_as::<_, AttendanceWithMember>(
             "SELECT att.attendance_id, att.member_id, att.date, att.is_present,
-                    att.time_in, att.time_out, mem.name, mem.year, mem.group_id
+                    att.time_in, att.time_out, mem.name, mem.year, mem.group_id, mem.track
              FROM Attendance att
              JOIN Member mem ON att.member_id = mem.member_id
              WHERE att.date = $1",

--- a/src/models/attendance.rs
+++ b/src/models/attendance.rs
@@ -57,4 +57,5 @@ pub struct AttendanceWithMember {
     pub name: String,
     pub year: i32,
     pub group_id: i32,
+    pub track: String,
 }


### PR DESCRIPTION
This PR updates the `attendanceByDate` query to return the `track` field from the `member` table. This change is intended to support upcoming functionality in amD that groups attendance data by tracks rather than by year.