### PR TITLE
add : Added a query to know attendance count between two dates 

### DIFF
--- a/src/graphql/queries/member_queries.rs
+++ b/src/graphql/queries/member_queries.rs
@@ -139,4 +139,79 @@ impl Member {
 
         Ok(history)
     }
+
+    async fn present_count_by_date(
+        &self,
+        ctx: &Context<'_>,
+        start_date: NaiveDate,
+        end_date: NaiveDate,
+    ) -> Result<i64> {
+        if end_date < start_date {
+            return Err("end_date must be >= start_date".into());
+        }
+
+        let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
+
+        let records: i64 = sqlx::query_scalar(
+            "
+        SELECT COUNT(att.is_present)
+        FROM attendance att
+        INNER JOIN member m ON att.member_id = m.member_id
+        WHERE att.member_id = $3
+          AND att.is_present = true
+          AND att.date BETWEEN $1 AND $2",
+        )
+        .bind(start_date)
+        .bind(end_date)
+        .bind(self.member_id)
+        .fetch_one(pool.as_ref())
+        .await?;
+
+        Ok(records)
+    }
+
+    async fn absent_count_by_date(
+        &self,
+        ctx: &Context<'_>,
+        start_date: NaiveDate,
+        end_date: NaiveDate,
+    ) -> Result<i64> {
+        if end_date < start_date {
+            return Err("end_date must be >= start_date".into());
+        }
+
+        let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
+
+        let working_days: i64 = sqlx::query_scalar(
+            "
+        SELECT COUNT(*) 
+        FROM (
+        SELECT date
+        FROM attendance
+        where date between $1 and $2 GROUP BY date
+        HAVING BOOL_or(is_present = true)
+        );
+        ",
+        )
+        .bind(start_date)
+        .bind(end_date)
+        .fetch_one(pool.as_ref())
+        .await?;
+
+        let present: i64 = sqlx::query_scalar(
+            "
+        SELECT COUNT(att.is_present)
+        FROM attendance att
+        WHERE att.member_id = $3
+          AND att.is_present = true
+          AND att.date BETWEEN $1 AND $2",
+        )
+        .bind(start_date)
+        .bind(end_date)
+        .bind(self.member_id)
+        .fetch_one(pool.as_ref())
+        .await?;
+
+        Ok(working_days - present)
+    }
 }


### PR DESCRIPTION
These queries calculate a member's present/absent days between two dates (excluding holidays), simplifying attendance tracking.