### PR TITLE
feat: implement status update breaks

### DIFF
--- a/migrations/20251013082516_implement_status_breaks.sql
+++ b/migrations/20251013082516_implement_status_breaks.sql
@@ -1,0 +1,8 @@
+-- Add migration script here
+CREATE TABLE statusbreaks (
+    id SERIAL PRIMARY KEY,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    year INT NOT NULL,
+    reason TEXT
+);

--- a/src/models/status_update.rs
+++ b/src/models/status_update.rs
@@ -3,6 +3,7 @@ use chrono::NaiveDate;
 use sqlx::FromRow;
 
 #[derive(SimpleObject, FromRow)]
+#[graphql(complex)]
 pub struct StatusUpdateRecord {
     pub update_id: i32,
     pub member_id: i32,

--- a/src/models/status_update.rs
+++ b/src/models/status_update.rs
@@ -1,4 +1,4 @@
-use async_graphql::SimpleObject;
+use async_graphql::{InputObject, SimpleObject};
 use chrono::NaiveDate;
 use sqlx::FromRow;
 
@@ -14,4 +14,21 @@ pub struct StatusUpdateRecord {
 pub struct StatusUpdateStreakRecord {
     pub current_streak: Option<i64>,
     pub max_streak: Option<i64>,
+}
+
+#[derive(SimpleObject, FromRow)]
+pub struct StatusBreakRecord {
+    pub id: i32,
+    pub start_date: NaiveDate,
+    pub end_date: NaiveDate,
+    pub year: i32,
+    pub reason: Option<String>,
+}
+
+#[derive(InputObject)]
+pub struct CreateStatusBreakInput {
+    pub start_date: NaiveDate,
+    pub end_date: NaiveDate,
+    pub year: i32,
+    pub reason: Option<String>,
 }


### PR DESCRIPTION
Adds a new table to track when status update streak tracking should be paused for a batch.

Integrated the above with the miss-streak calculation and added a new attribute `on_break` to the `on_date` status update query.