### PR TITLE
fix: prevent crash over missing some env vars

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,10 +32,10 @@ impl Config {
     fn from_env() -> Self {
         let _ = dotenv::dotenv();
         Self {
-            env: std::env::var("ROOT_ENV").unwrap_or_else(|_| "development".to_string()),
-            secret_key: std::env::var("ROOT_SECRET").expect("ROOT_SECRET must be set."),
+            env: std::env::var("ROOT_ENV").unwrap_or("development".to_string()),
+            secret_key: std::env::var("ROOT_SECRET").unwrap_or("insecuresecret".to_string()),
             database_url: std::env::var("ROOT_DB_URL").expect("ROOT_DB_URL must be set."),
-            port: std::env::var("ROOT_PORT").expect("ROOT_PORT must be set."),
+            port: std::env::var("ROOT_PORT").unwrap_or("12345".to_string()),
             seeding_enabled: std::env::var("SEEDING_ENABLED")
                 .map(|v| v.to_lowercase() == "true")
                 .unwrap_or(false),


### PR DESCRIPTION
Environment variables like "ROOT_SECRET" and "ROOT_PORT" can have sensible defaults and does not need to nag the user to set them in order to start. Provide default values in case they are not found in env.

Additionally, the default provided for ROOT_ENV is passed in through `unwrap_or_else`, but this extra lazy evaluation isn't optimizing much and only hinders readability. Change this to `unwrap_or` as simple strings are not compute heavy enough to warrant the lazy eval.