### PR TITLE
chore: Add is_alumni attribute to Member object

### DIFF
--- a/migrations/20251103160042_add_alumni_attribute.sql
+++ b/migrations/20251103160042_add_alumni_attribute.sql
@@ -1,0 +1,8 @@
+-- Add migration script here
+ALTER TABLE Member
+ADD COLUMN is_alumni BOOLEAN DEFAULT FALSE;
+
+-- Creating a view 'active_members' to filter out alumni
+CREATE VIEW active_members AS
+SELECT * FROM Member
+WHERE is_alumni = FALSE;

--- a/src/daily_task/mod.rs
+++ b/src/daily_task/mod.rs
@@ -38,7 +38,7 @@ pub async fn run_daily_task_at_midnight(pool: Arc<PgPool>) {
 /// * Insert new attendance records everyday for [`presense`](https://www.github.com/amfoss/presense) to update them later in the day.
 async fn execute_daily_task(pool: Arc<PgPool>) {
     // Members is queried outside of each function to avoid repetition
-    let members = sqlx::query_as::<_, Member>("SELECT * FROM Member")
+    let members = sqlx::query_as::<_, Member>("SELECT * FROM active_members")
         .fetch_all(&*pool)
         .await;
 

--- a/src/database_seeder/seed.sql
+++ b/src/database_seeder/seed.sql
@@ -1,6 +1,6 @@
 -- Member
 INSERT INTO member (
-    roll_no, name, email, sex, year, hostel, mac_address, discord_id, group_id, track, github_user
+    roll_no, name, email, sex, year, hostel, mac_address, discord_id, group_id, track, github_user, is_alumni
 )
 SELECT 
     'R' || LPAD(i::TEXT, 4, '0'),
@@ -28,7 +28,8 @@ SELECT
     'discord_user_' || i,
     (i % 8) + 1,
     'track ' || ((i%4)+1),
-    'github_user_' || i
+    'github_user_' || i,
+    (i % 2 = 0)
 FROM generate_series(1, 60) AS i
 ON CONFLICT (roll_no) DO NOTHING;
 

--- a/src/graphql/mutations/member_mutations.rs
+++ b/src/graphql/mutations/member_mutations.rs
@@ -16,7 +16,7 @@ impl MemberMutations {
         let now = Local::now().with_timezone(&Kolkata).date_naive();
 
         let member = sqlx::query_as::<_, Member>(
-            "INSERT INTO Member (roll_no, name, email, sex, year, hostel, mac_address, discord_id, group_id, track, github_user, created_at)
+            "INSERT INTO Member (roll_no, name, email, sex, year, hostel, mac_address, discord_id, group_id, track, github_user, is_alumni, created_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING *"
         )
         .bind(&input.roll_no)
@@ -30,6 +30,7 @@ impl MemberMutations {
         .bind(input.group_id)
         .bind(&input.track)
         .bind(&input.github_user)
+        .bind(false)
         .bind(now)
         .fetch_one(pool.as_ref())
         .await?;
@@ -53,7 +54,8 @@ impl MemberMutations {
                 discord_id = COALESCE($8, discord_id),
                 group_id = COALESCE($9, group_id),
                 track = COALESCE($10, track),
-                github_user = COALESCE($11, github_user)
+                github_user = COALESCE($11, github_user),
+                is_alumni = COALESCE($12, is_alumni)
             WHERE member_id = $12
             RETURNING *",
         )
@@ -68,6 +70,7 @@ impl MemberMutations {
         .bind(input.group_id)
         .bind(&input.track)
         .bind(&input.github_user)
+        .bind(input.is_alumni)
         .bind(input.member_id)
         .fetch_one(pool.as_ref())
         .await?;

--- a/src/graphql/mutations/member_mutations.rs
+++ b/src/graphql/mutations/member_mutations.rs
@@ -17,7 +17,7 @@ impl MemberMutations {
 
         let member = sqlx::query_as::<_, Member>(
             "INSERT INTO Member (roll_no, name, email, sex, year, hostel, mac_address, discord_id, group_id, track, github_user, is_alumni, created_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING *"
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING *"
         )
         .bind(&input.roll_no)
         .bind(&input.name)
@@ -56,7 +56,7 @@ impl MemberMutations {
                 track = COALESCE($10, track),
                 github_user = COALESCE($11, github_user),
                 is_alumni = COALESCE($12, is_alumni)
-            WHERE member_id = $12
+            WHERE member_id = $13
             RETURNING *",
         )
         .bind(&input.roll_no)

--- a/src/graphql/mutations/status_mutations.rs
+++ b/src/graphql/mutations/status_mutations.rs
@@ -21,7 +21,7 @@ impl StatusMutations {
         let status = sqlx::query_as::<_, StatusUpdateRecord>(
             "UPDATE StatusUpdateHistory SET
                 is_sent = true
-            WHERE member_id IN (SELECT member_id from Member where email = ANY($1))
+            WHERE member_id IN (SELECT member_id from active_members where email = ANY($1))
             AND date = $2
             RETURNING *
             ",

--- a/src/graphql/queries/member_queries.rs
+++ b/src/graphql/queries/member_queries.rs
@@ -27,7 +27,7 @@ impl MemberQueries {
     ) -> Result<Vec<Member>> {
         let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
 
-        let mut query = sqlx::QueryBuilder::new("SELECT * FROM Member WHERE 1=1");
+        let mut query = sqlx::QueryBuilder::new("SELECT * FROM active_members WHERE 1=1");
 
         if let Some(y) = year {
             query.push(" AND year = ");
@@ -57,18 +57,20 @@ impl MemberQueries {
 
         match (member_id, email) {
             (Some(id), None) => {
-                let member =
-                    sqlx::query_as::<_, Member>("SELECT * FROM Member WHERE member_id = $1")
-                        .bind(id)
-                        .fetch_optional(pool.as_ref())
-                        .await?;
+                let member = sqlx::query_as::<_, Member>(
+                    "SELECT * FROM active_members WHERE member_id = $1",
+                )
+                .bind(id)
+                .fetch_optional(pool.as_ref())
+                .await?;
                 Ok(member)
             }
             (None, Some(email)) => {
-                let member = sqlx::query_as::<_, Member>("SELECT * FROM Member WHERE email = $1")
-                    .bind(email)
-                    .fetch_optional(pool.as_ref())
-                    .await?;
+                let member =
+                    sqlx::query_as::<_, Member>("SELECT * FROM active_members WHERE email = $1")
+                        .bind(email)
+                        .fetch_optional(pool.as_ref())
+                        .await?;
                 Ok(member)
             }
             (Some(_), Some(_)) => Err("Provide only one of member_id or email".into()),
@@ -178,7 +180,7 @@ impl StatusInfo {
                 is_sent = TRUE
                 OR NOT EXISTS (
                     SELECT * FROM StatusBreaks sb
-                    WHERE year = (SELECT year from Member where member_id=$1)
+                    WHERE year = (SELECT year from active_members where member_id=$1)
                     AND suh.date BETWEEN sb.start_date AND sb.end_date
                 )
               )
@@ -222,7 +224,7 @@ impl StatusUpdateRecord {
         let is_on_break = sqlx::query_scalar(
             "SELECT EXISTS (
                 SELECT 1 from StatusBreaks
-                WHERE year = (SELECT year FROM Member WHERE member_id = $1)
+                WHERE year = (SELECT year FROM active_members WHERE member_id = $1)
                 AND $2 BETWEEN start_date AND end_date
             )",
         )

--- a/src/models/member.rs
+++ b/src/models/member.rs
@@ -25,6 +25,7 @@ pub struct Member {
     pub group_id: i32,
     pub track: Option<String>,
     pub github_user: Option<String>,
+    pub is_alumni: bool,
     #[graphql(skip)] // Don't expose internal fields/meta-data
     pub created_at: NaiveDateTime,
 }
@@ -58,4 +59,5 @@ pub struct UpdateMemberInput {
     pub group_id: Option<i32>,
     pub track: Option<String>,
     pub github_user: Option<String>,
+    pub is_alumni: Option<bool>,
 }


### PR DESCRIPTION
This PR introduce the 'is_alumni' attribute to the 'Member' object to keep track of members who have graduated

- Added a view called `active_members` which filters out alumni by selecting rows where 'is_alumni' is set to false

- Updated the queries accordingly to make use of `active_members'

Closes #155 