### PR TITLE
Leave tracking from amD

### DIFF
--- a/migrations/20260214152404_create_leave_table.sql
+++ b/migrations/20260214152404_create_leave_table.sql
@@ -1,0 +1,11 @@
+-- Leave table for tracking leaves
+CREATE TABLE Leave (
+        leave_id SERIAL PRIMARY KEY,
+        discord_id VARCHAR(255) REFERENCES Member(discord_id) ON DELETE CASCADE,
+        date DATE DEFAULT CURRENT_DATE,
+        duration INT DEFAULt 1,
+        reason TEXT NOT NULL,
+        approved_by VARCHAR(255) REFERENCES Member(discord_id),
+        CHECK (approved_by IS NULL OR approved_by <> discord_id),
+        UNIQUE (date, discord_id)
+);

--- a/migrations/20260214152404_create_leave_table.sql
+++ b/migrations/20260214152404_create_leave_table.sql
@@ -1,12 +1,13 @@
 -- Leave table for tracking leaves
 CREATE TABLE Leave (
         leave_id SERIAL PRIMARY KEY,
-        discord_id VARCHAR(255) REFERENCES Member(discord_id) ON DELETE CASCADE,
-        from_date DATE DEFAULT CURRENT_DATE,
-        duration INT DEFAULT 1,
+        discord_id VARCHAR(255) NOT NULL REFERENCES Member(discord_id) ON DELETE CASCADE,
+        from_date DATE DEFAULT CURRENT_DATE NOT NULL,
+        duration INT DEFAULT 1 NOT NULL,
         reason TEXT NOT NULL,
-        applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        approved_by VARCHAR(255) REFERENCES Member(discord_id),
+        applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        approved_by VARCHAR(255) REFERENCES Member(discord_id) ON DELETE SET NULL,
         CHECK (approved_by IS NULL OR approved_by <> discord_id),
+        CHECK (duration > 0),
         UNIQUE (from_date, discord_id)
 );

--- a/migrations/20260214152404_create_leave_table.sql
+++ b/migrations/20260214152404_create_leave_table.sql
@@ -2,10 +2,11 @@
 CREATE TABLE Leave (
         leave_id SERIAL PRIMARY KEY,
         discord_id VARCHAR(255) REFERENCES Member(discord_id) ON DELETE CASCADE,
-        date DATE DEFAULT CURRENT_DATE,
-        duration INT DEFAULt 1,
+        from_date DATE DEFAULT CURRENT_DATE,
+        duration INT DEFAULT 1,
         reason TEXT NOT NULL,
+        applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         approved_by VARCHAR(255) REFERENCES Member(discord_id),
         CHECK (approved_by IS NULL OR approved_by <> discord_id),
-        UNIQUE (date, discord_id)
+        UNIQUE (from_date, discord_id)
 );

--- a/src/graphql/mutations/attendance_mutations.rs
+++ b/src/graphql/mutations/attendance_mutations.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use async_graphql::{Context, Object, Result};
-use chrono::{NaiveDate, NaiveDateTime};
+use chrono::NaiveDate;
 use chrono_tz::Asia::Kolkata;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use sqlx::PgPool;
 
 use crate::auth::guards::AdminOrBotGuard;
-use crate::models::attendance::{AttendanceRecord, MarkAttendanceInput, MarkLeaveOutput};
+use crate::models::attendance::{AttendanceRecord, LeaveRecord, MarkAttendanceInput};
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -69,24 +69,22 @@ impl AttendanceMutations {
         ctx: &Context<'_>,
         discord_id: String,
         reason: String,
-        applied_at: NaiveDateTime,
         from_date: NaiveDate,
         duration: i32,
-    ) -> Result<MarkLeaveOutput> {
+    ) -> Result<LeaveRecord> {
         let pool = ctx
             .data::<Arc<PgPool>>()
             .expect("Pool not found in context");
 
-        let leave: MarkLeaveOutput = sqlx::query_as::<_, MarkLeaveOutput>(
+        let leave: LeaveRecord = sqlx::query_as::<_, LeaveRecord>(
             "INSERT INTO Leave
-            (discord_id, reason, applied_at, from_date, duration) 
-            VALUES ($1, $2, $3, $4, $5)
+            (discord_id, reason, from_date, duration) 
+            VALUES ($1, $2, $3, $4)
             RETURNING *
             ",
         )
         .bind(discord_id)
         .bind(reason)
-        .bind(applied_at)
         .bind(from_date)
         .bind(duration)
         .fetch_one(pool.as_ref())
@@ -100,23 +98,28 @@ impl AttendanceMutations {
         &self,
         ctx: &Context<'_>,
         discord_id: String,
+        from_date: NaiveDate,
         approved_by: String,
-    ) -> Result<MarkLeaveOutput> {
+    ) -> Result<LeaveRecord> {
         let pool = ctx
             .data::<Arc<PgPool>>()
             .expect("Pool not found in context");
 
-        let leave: MarkLeaveOutput = sqlx::query_as::<_, MarkLeaveOutput>(
+        let leave: LeaveRecord = sqlx::query_as::<_, LeaveRecord>(
             "UPDATE Leave
             SET approved_by = $1
-            WHERE discord_id = $2
+            WHERE discord_id = $2 AND
+            from_date=$3 AND
+            approved_by IS NULL
             RETURNING *
             ",
         )
         .bind(approved_by)
         .bind(discord_id)
-        .fetch_one(pool.as_ref())
-        .await?;
+        .bind(from_date)
+        .fetch_optional(pool.as_ref())
+        .await?
+        .ok_or_else(|| async_graphql::Error::new("no pending leave found to approve"))?;
 
         Ok(leave)
     }

--- a/src/graphql/mutations/attendance_mutations.rs
+++ b/src/graphql/mutations/attendance_mutations.rs
@@ -7,7 +7,9 @@ use sha2::Sha256;
 use sqlx::PgPool;
 
 use crate::auth::guards::AdminOrBotGuard;
-use crate::models::attendance::{AttendanceRecord, MarkAttendanceInput, MarkLeaveInput, MarkLeaveOutput};
+use crate::models::attendance::{
+    AttendanceRecord, MarkAttendanceInput, MarkLeaveInput, MarkLeaveOutput,
+};
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -71,7 +73,7 @@ impl AttendanceMutations {
             .data::<Arc<PgPool>>()
             .expect("Pool not found in context");
         let now = chrono::Utc::now().with_timezone(&Kolkata);
-        
+
         let leave: MarkLeaveOutput = sqlx::query_as::<_, MarkLeaveOutput>(
             "INSERT INTO Leave
             (discord_id, date, duration, reason, approved_by) 

--- a/src/graphql/mutations/attendance_mutations.rs
+++ b/src/graphql/mutations/attendance_mutations.rs
@@ -7,7 +7,7 @@ use sha2::Sha256;
 use sqlx::PgPool;
 
 use crate::auth::guards::AdminOrBotGuard;
-use crate::models::attendance::{AttendanceRecord, MarkAttendanceInput};
+use crate::models::attendance::{AttendanceRecord, MarkAttendanceInput, MarkLeaveInput, MarkLeaveOutput};
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -60,5 +60,33 @@ impl AttendanceMutations {
         .await?;
 
         Ok(attendance)
+    }
+
+    async fn mark_leave(
+        &self,
+        ctx: &Context<'_>,
+        input: MarkLeaveInput,
+    ) -> Result<MarkLeaveOutput> {
+        let pool = ctx
+            .data::<Arc<PgPool>>()
+            .expect("Pool not found in context");
+        let now = chrono::Utc::now().with_timezone(&Kolkata);
+        
+        let leave: MarkLeaveOutput = sqlx::query_as::<_, MarkLeaveOutput>(
+            "INSERT INTO Leave
+            (discord_id, date, duration, reason, approved_by) 
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING *
+            ",
+        )
+        .bind(input.discord_id)
+        .bind(now)
+        .bind(input.duration)
+        .bind(input.reason)
+        .bind(input.approved_by)
+        .fetch_one(pool.as_ref())
+        .await?;
+
+        Ok(leave)
     }
 }

--- a/src/graphql/mutations/attendance_mutations.rs
+++ b/src/graphql/mutations/attendance_mutations.rs
@@ -1,16 +1,14 @@
 use std::sync::Arc;
 
 use async_graphql::{Context, Object, Result};
-use chrono::{NaiveDateTime, NaiveDate};
+use chrono::{NaiveDate, NaiveDateTime};
 use chrono_tz::Asia::Kolkata;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use sqlx::PgPool;
 
 use crate::auth::guards::AdminOrBotGuard;
-use crate::models::attendance::{
-    AttendanceRecord, MarkAttendanceInput, MarkLeaveOutput
-};
+use crate::models::attendance::{AttendanceRecord, MarkAttendanceInput, MarkLeaveOutput};
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -73,7 +71,7 @@ impl AttendanceMutations {
         reason: String,
         applied_at: NaiveDateTime,
         from_date: NaiveDate,
-        duration: i32
+        duration: i32,
     ) -> Result<MarkLeaveOutput> {
         let pool = ctx
             .data::<Arc<PgPool>>()

--- a/src/graphql/mutations/attendance_mutations.rs
+++ b/src/graphql/mutations/attendance_mutations.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_graphql::{Context, Object, Result};
+use chrono::{NaiveDateTime, NaiveDate};
 use chrono_tz::Asia::Kolkata;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
@@ -8,7 +9,7 @@ use sqlx::PgPool;
 
 use crate::auth::guards::AdminOrBotGuard;
 use crate::models::attendance::{
-    AttendanceRecord, MarkAttendanceInput, MarkLeaveInput, MarkLeaveOutput,
+    AttendanceRecord, MarkAttendanceInput, MarkLeaveOutput
 };
 
 type HmacSha256 = Hmac<Sha256>;
@@ -64,28 +65,58 @@ impl AttendanceMutations {
         Ok(attendance)
     }
 
-    async fn mark_leave(
+    #[graphql(name = "leaveApplication", guard = "AdminOrBotGuard")]
+    async fn leave_application(
         &self,
         ctx: &Context<'_>,
-        input: MarkLeaveInput,
+        discord_id: String,
+        reason: String,
+        applied_at: NaiveDateTime,
+        from_date: NaiveDate,
+        duration: i32
     ) -> Result<MarkLeaveOutput> {
         let pool = ctx
             .data::<Arc<PgPool>>()
             .expect("Pool not found in context");
-        let now = chrono::Utc::now().with_timezone(&Kolkata);
 
         let leave: MarkLeaveOutput = sqlx::query_as::<_, MarkLeaveOutput>(
             "INSERT INTO Leave
-            (discord_id, date, duration, reason, approved_by) 
+            (discord_id, reason, applied_at, from_date, duration) 
             VALUES ($1, $2, $3, $4, $5)
             RETURNING *
             ",
         )
-        .bind(input.discord_id)
-        .bind(now)
-        .bind(input.duration)
-        .bind(input.reason)
-        .bind(input.approved_by)
+        .bind(discord_id)
+        .bind(reason)
+        .bind(applied_at)
+        .bind(from_date)
+        .bind(duration)
+        .fetch_one(pool.as_ref())
+        .await?;
+
+        Ok(leave)
+    }
+
+    #[graphql(name = "approveLeave", guard = "AdminOrBotGuard")]
+    async fn approve_leave(
+        &self,
+        ctx: &Context<'_>,
+        discord_id: String,
+        approved_by: String,
+    ) -> Result<MarkLeaveOutput> {
+        let pool = ctx
+            .data::<Arc<PgPool>>()
+            .expect("Pool not found in context");
+
+        let leave: MarkLeaveOutput = sqlx::query_as::<_, MarkLeaveOutput>(
+            "UPDATE Leave
+            SET approved_by = $1
+            WHERE discord_id = $2
+            RETURNING *
+            ",
+        )
+        .bind(approved_by)
+        .bind(discord_id)
         .fetch_one(pool.as_ref())
         .await?;
 

--- a/src/graphql/queries/member_queries.rs
+++ b/src/graphql/queries/member_queries.rs
@@ -1,6 +1,9 @@
 use crate::auth::guards::AuthGuard;
 use crate::auth::AuthContext;
-use crate::models::{attendance::AttendanceRecord, status_update::StatusUpdateRecord};
+use crate::models::{
+    attendance::{AttendanceRecord, LeaveCountOutput},
+    status_update::StatusUpdateRecord,
+};
 use async_graphql::{ComplexObject, Context, Object, Result};
 use chrono::NaiveDate;
 use sqlx::PgPool;
@@ -396,5 +399,38 @@ impl Member {
         AttendanceInfo {
             member_id: self.member_id,
         }
+    }
+
+    async fn leave_count(
+        &self,
+        ctx: &Context<'_>,
+        start_date: NaiveDate,
+        end_date: NaiveDate,
+    ) -> Result<LeaveCountOutput> {
+        let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
+
+        if end_date < start_date {
+            return Err("end_date must be >= start_date".into());
+        }
+        let leave = sqlx::query_as::<_, LeaveCountOutput>(
+            r#"
+                SELECT discord_id, SUM(duration) AS count
+                FROM "Leave"
+                WHERE date > $1
+                  AND (date + duration) < $2
+                  AND discord_id = $3
+                GROUP BY discord_id
+                "#,
+        )
+        .bind(start_date)
+        .bind(end_date)
+        .bind(
+            self.discord_id
+                .as_ref()
+                .expect("Leave count needs discord_id"),
+        )
+        .fetch_one(pool.as_ref())
+        .await?;
+        Ok(leave)
     }
 }

--- a/src/graphql/queries/member_queries.rs
+++ b/src/graphql/queries/member_queries.rs
@@ -1,9 +1,6 @@
 use crate::auth::guards::AuthGuard;
 use crate::auth::AuthContext;
-use crate::models::{
-    attendance::{AttendanceRecord, LeaveCountOutput},
-    status_update::StatusUpdateRecord,
-};
+use crate::models::{attendance::AttendanceRecord, status_update::StatusUpdateRecord};
 use async_graphql::{ComplexObject, Context, Object, Result};
 use chrono::NaiveDate;
 use sqlx::PgPool;
@@ -406,21 +403,24 @@ impl Member {
         ctx: &Context<'_>,
         start_date: NaiveDate,
         end_date: NaiveDate,
-    ) -> Result<LeaveCountOutput> {
+    ) -> Result<i64> {
         let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
 
         if end_date < start_date {
             return Err("end_date must be >= start_date".into());
         }
-        let leave = sqlx::query_as::<_, LeaveCountOutput>(
+        let total: Option<i64> = sqlx::query_scalar(
             r#"
-                SELECT discord_id, SUM(duration) AS count
-                FROM "Leave"
-                WHERE date > $1
-                  AND (date + duration) < $2
-                  AND discord_id = $3
-                GROUP BY discord_id
-                "#,
+            SELECT SUM(
+                LEAST(from_date + duration - 1, $2)
+                - GREATEST(from_date, $1)
+                + 1
+            )
+            FROM leave
+            WHERE from_date <= $2
+              AND (from_date + duration - 1) >= $1
+              AND discord_id = $3
+            "#,
         )
         .bind(start_date)
         .bind(end_date)
@@ -431,6 +431,6 @@ impl Member {
         )
         .fetch_one(pool.as_ref())
         .await?;
-        Ok(leave)
+        Ok(total.unwrap_or(0))
     }
 }

--- a/src/graphql/queries/member_queries.rs
+++ b/src/graphql/queries/member_queries.rs
@@ -57,11 +57,12 @@ impl MemberQueries {
         ctx: &Context<'_>,
         member_id: Option<i32>,
         email: Option<String>,
+        discord_id: Option<String>,
     ) -> Result<Option<Member>> {
         let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
 
-        match (member_id, email) {
-            (Some(id), None) => {
+        match (member_id, email, discord_id) {
+            (Some(id), None, None) => {
                 let member =
                     sqlx::query_as::<_, Member>("SELECT * FROM Member WHERE member_id = $1")
                         .bind(id)
@@ -69,19 +70,26 @@ impl MemberQueries {
                         .await?;
                 Ok(member)
             }
-            (None, Some(email)) => {
+            (None, Some(email), None) => {
                 let member = sqlx::query_as::<_, Member>("SELECT * FROM Member WHERE email = $1")
                     .bind(email)
                     .fetch_optional(pool.as_ref())
                     .await?;
                 Ok(member)
             }
-            (Some(_), Some(_)) => Err("Provide only one of member_id or email".into()),
-            (None, None) => Err("Provide either member_id or email".into()),
+            (None, None, Some(discord_id)) => {
+                let member =
+                    sqlx::query_as::<_, Member>("SELECT * FROM Member WHERE discord_id = $1")
+                        .bind(discord_id)
+                        .fetch_optional(pool.as_ref())
+                        .await?;
+                Ok(member)
+            }
+            _ => Err("Provide exactly one of member_id, email, or discord_id".into()),
         }
     }
 
-    /// Fetch the details of the currently logged in member
+    // Fetch the details of the currently logged in member
     #[graphql(guard = "AuthGuard")]
     async fn me(&self, ctx: &Context<'_>) -> Result<Member> {
         let auth = ctx.data::<AuthContext>()?;

--- a/src/graphql/queries/member_queries.rs
+++ b/src/graphql/queries/member_queries.rs
@@ -91,7 +91,7 @@ impl MemberQueries {
         }
     }
 
-    // Fetch the details of the currently logged in member
+    /// Fetch the details of the currently logged in member
     #[graphql(guard = "AuthGuard")]
     async fn me(&self, ctx: &Context<'_>) -> Result<Member> {
         let auth = ctx.data::<AuthContext>()?;
@@ -434,11 +434,16 @@ impl Member {
         start_date: NaiveDate,
         end_date: NaiveDate,
     ) -> Result<i64> {
-        let pool = ctx.data::<Arc<PgPool>>().expect("Pool must be in context.");
+        let pool = ctx.data::<Arc<PgPool>>()?;
 
         if end_date < start_date {
             return Err("end_date must be >= start_date".into());
         }
+        let discord_id = self
+            .discord_id
+            .as_ref()
+            .expect("Leave count needs discord_id");
+
         let total: Option<i64> = sqlx::query_scalar(
             r#"
             SELECT SUM(
@@ -454,11 +459,7 @@ impl Member {
         )
         .bind(start_date)
         .bind(end_date)
-        .bind(
-            self.discord_id
-                .as_ref()
-                .expect("Leave count needs discord_id"),
-        )
+        .bind(discord_id)
         .fetch_one(pool.as_ref())
         .await?;
         Ok(total.unwrap_or(0))

--- a/src/models/attendance.rs
+++ b/src/models/attendance.rs
@@ -31,9 +31,3 @@ pub struct MarkLeaveOutput {
     pub duration: i32,
     pub approved_by: Option<String>,
 }
-
-#[derive(SimpleObject, FromRow)]
-pub struct LeaveCountOutput {
-    pub discord_id: String,
-    pub count: i32,
-}

--- a/src/models/attendance.rs
+++ b/src/models/attendance.rs
@@ -21,3 +21,20 @@ pub struct MarkAttendanceInput {
     pub date: NaiveDate,
     pub hmac_signature: String,
 }
+
+#[derive(InputObject)]
+pub struct MarkLeaveInput {
+    pub discord_id: String,
+    pub reason: String,
+    pub duration: i32,
+    pub approved_by: Option<String>,
+}
+
+#[derive(SimpleObject, FromRow)]
+pub struct MarkLeaveOutput {
+    pub discord_id: String,
+    pub date: NaiveDate,
+    pub reason: String,
+    pub duration: i32,
+    pub approved_by: Option<String>,
+}

--- a/src/models/attendance.rs
+++ b/src/models/attendance.rs
@@ -38,3 +38,9 @@ pub struct MarkLeaveOutput {
     pub duration: i32,
     pub approved_by: Option<String>,
 }
+
+#[derive(SimpleObject, FromRow)]
+pub struct LeaveCountOutput {
+    pub discord_id: String,
+    pub count: i32,
+}

--- a/src/models/attendance.rs
+++ b/src/models/attendance.rs
@@ -23,7 +23,7 @@ pub struct MarkAttendanceInput {
 }
 
 #[derive(SimpleObject, FromRow)]
-pub struct MarkLeaveOutput {
+pub struct LeaveRecord {
     pub discord_id: String,
     pub from_date: NaiveDate,
     pub applied_at: NaiveDateTime,

--- a/src/models/attendance.rs
+++ b/src/models/attendance.rs
@@ -22,18 +22,11 @@ pub struct MarkAttendanceInput {
     pub hmac_signature: String,
 }
 
-#[derive(InputObject)]
-pub struct MarkLeaveInput {
-    pub discord_id: String,
-    pub reason: String,
-    pub duration: i32,
-    pub approved_by: Option<String>,
-}
-
 #[derive(SimpleObject, FromRow)]
 pub struct MarkLeaveOutput {
     pub discord_id: String,
-    pub date: NaiveDate,
+    pub from_date: NaiveDate,
+    pub applied_at: NaiveDateTime,
     pub reason: String,
     pub duration: i32,
     pub approved_by: Option<String>,


### PR DESCRIPTION
This PR 
- creates a table `Leave` for 
  - mutations `leave_application` and `approve_leave`
  - query `leave_count`
- add `discord_id` optional param for `Member` object so amD can query using discord_id itself

`leave_count` can be called via member for specific member or allMembers to access leave records of all members

These are currently meant only to be accessed by amD for marking and fetching leaves