### PR TITLE
feat: add GraphQL queries and mutations for persisting member roles

### DIFF
--- a/migrations/20260310140619_create_member_roles.sql
+++ b/migrations/20260310140619_create_member_roles.sql
@@ -1,0 +1,5 @@
+-- Add member_roles table to support multiple roles per member
+CREATE TABLE MemberRoles (
+    discord_id VARCHAR(255) PRIMARY KEY, -- Use the Discord ID as the key
+    roles TEXT[] NOT NULL                -- Store roles as a PostgreSQL Array
+);

--- a/src/graphql/mutations/member_mutations.rs
+++ b/src/graphql/mutations/member_mutations.rs
@@ -53,4 +53,30 @@ impl MemberMutations {
 
         Ok(member)
     }
+
+    /// Save the roles of a member in the database
+    #[graphql(name = "saveMemberRoles", guard = "AuthGuard")]
+    async fn save_member_roles(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "discordId")] discord_id: String,
+        roles: Vec<String>,
+    ) -> Result<bool> {
+        let pool = ctx.data::<Arc<PgPool>>()?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO MemberRoles (discord_id, roles)
+            VALUES ($1, $2)
+            ON CONFLICT (discord_id)
+            DO UPDATE SET roles = EXCLUDED.roles
+            "#,
+        )
+        .bind(discord_id)
+        .bind(roles)
+        .execute(pool.as_ref())
+        .await?;
+
+        Ok(true)
+    }
 }

--- a/src/graphql/queries/member_queries.rs
+++ b/src/graphql/queries/member_queries.rs
@@ -89,6 +89,26 @@ impl MemberQueries {
         // The AuthGuard ensures that the user is authenticated, so we can unwrap here.
         Ok(auth.user.clone().unwrap())
     }
+
+    /// Fetch the roles of a member from the database
+    #[graphql(guard = "AuthGuard")]
+    async fn member_roles(
+    &self,
+    ctx: &Context<'_>,
+    #[graphql(name = "discordId")] discord_id: String,
+    ) -> Result<Option<Vec<String>>> {
+        let pool = ctx.data::<Arc<PgPool>>()?;
+
+        let roles: Option<Vec<String>> = sqlx::query_scalar(
+            "SELECT roles FROM MemberRoles WHERE discord_id = $1",
+        )
+        .bind(discord_id)
+        .fetch_optional(pool.as_ref())
+        .await?;
+
+        Ok(roles)
+    }
+
 }
 
 #[Object]

--- a/src/graphql/queries/member_queries.rs
+++ b/src/graphql/queries/member_queries.rs
@@ -1,6 +1,8 @@
 use crate::auth::guards::AuthGuard;
 use crate::auth::AuthContext;
-use crate::models::{attendance::AttendanceRecord, status_update::StatusUpdateRecord};
+use crate::models::{
+    attendance::AttendanceRecord, member::MemberRolesResponse, status_update::StatusUpdateRecord,
+};
 use async_graphql::{ComplexObject, Context, Object, Result};
 use chrono::NaiveDate;
 use sqlx::PgPool;
@@ -96,7 +98,7 @@ impl MemberQueries {
         &self,
         ctx: &Context<'_>,
         #[graphql(name = "discordId")] discord_id: String,
-    ) -> Result<Option<Vec<String>>> {
+    ) -> Result<MemberRolesResponse> {
         let pool = ctx.data::<Arc<PgPool>>()?;
 
         let roles: Option<Vec<String>> =
@@ -105,7 +107,17 @@ impl MemberQueries {
                 .fetch_optional(pool.as_ref())
                 .await?;
 
-        Ok(roles)
+        if let Some(r) = roles {
+            Ok(MemberRolesResponse {
+                exists: true,
+                roles: r,
+            })
+        } else {
+            Ok(MemberRolesResponse {
+                exists: false,
+                roles: vec![],
+            })
+        }
     }
 }
 

--- a/src/graphql/queries/member_queries.rs
+++ b/src/graphql/queries/member_queries.rs
@@ -93,22 +93,20 @@ impl MemberQueries {
     /// Fetch the roles of a member from the database
     #[graphql(guard = "AuthGuard")]
     async fn member_roles(
-    &self,
-    ctx: &Context<'_>,
-    #[graphql(name = "discordId")] discord_id: String,
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "discordId")] discord_id: String,
     ) -> Result<Option<Vec<String>>> {
         let pool = ctx.data::<Arc<PgPool>>()?;
 
-        let roles: Option<Vec<String>> = sqlx::query_scalar(
-            "SELECT roles FROM MemberRoles WHERE discord_id = $1",
-        )
-        .bind(discord_id)
-        .fetch_optional(pool.as_ref())
-        .await?;
+        let roles: Option<Vec<String>> =
+            sqlx::query_scalar("SELECT roles FROM MemberRoles WHERE discord_id = $1")
+                .bind(discord_id)
+                .fetch_optional(pool.as_ref())
+                .await?;
 
         Ok(roles)
     }
-
 }
 
 #[Object]

--- a/src/models/member.rs
+++ b/src/models/member.rs
@@ -60,3 +60,9 @@ pub struct UpdateMemberInput {
     pub track: Option<String>,
     pub github_user: Option<String>,
 }
+
+#[derive(SimpleObject)]
+pub struct MemberRolesResponse {
+    pub exists: bool,
+    pub roles: Vec<String>,
+}


### PR DESCRIPTION
## Overview

Adds backend support for persisting Discord member roles so that the AMD bot can restore them when a user rejoins the server.

## Changes

- Introduced `MemberRoles` storage for saving role IDs associated with a Discord user.
- Added GraphQL operations:
  - `save_member_roles` mutation to store roles when a user leaves.
  - `member_roles` query to retrieve stored roles when a user rejoins.

These endpoints are protected with `AuthGuard` guards to ensure they are only accessible to the bot.

## Related PR

This PR supports the role persistence feature implemented in **amd**:

➡  [`Main PR`](https://github.com/amfoss/amd/pull/104)